### PR TITLE
ISBN-13 check digit generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,19 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  # RSpec to run every build
+  # test:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #
+  #     - name: Set up Ruby
+  #       uses: ruby/setup-ruby@v1
+  #       with:
+  #         ruby-version: .ruby-version
+  #         bundler-cache: true
+  #
+  #     - name: Run tests
+  #       run: bundle exec rspec
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,19 +53,18 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
-  # RSpec to run every build
-  # test:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #
-  #     - name: Set up Ruby
-  #       uses: ruby/setup-ruby@v1
-  #       with:
-  #         ruby-version: .ruby-version
-  #         bundler-cache: true
-  #
-  #     - name: Run tests
-  #       run: bundle exec rspec
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rspec
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+spec/examples.txt

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ See [docs/check_digit_generator.md](docs/check_digit_generator.md) for detailed 
 
 ## Usage
 
+### Rake task
+
+```bash
+rake isbn:check_digit[978014300723]
+# => 9780143007234
+```
+
+### In Ruby
+
 ```ruby
 generator = CheckedBarcodeGenerator.perform("978014300723")
 generator.success? # => true

--- a/README.md
+++ b/README.md
@@ -1,24 +1,43 @@
-# README
+# CirclePOS Test — ISBN-13 Check Digit Generator
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+A Rails service that calculates the check digit for an ISBN-13 barcode.
 
-Things you may want to cover:
+## Requirements
 
-* Ruby version
+- Ruby 3.4.5
+- Rails 8.0
 
-* System dependencies
+## Setup
 
-* Configuration
+```bash
+bundle install
+```
 
-* Database creation
+## Running Tests
 
-* Database initialization
+```bash
+bundle exec rspec
+```
 
-* How to run the test suite
+## Algorithm
 
-* Services (job queues, cache servers, search engines, etc.)
+Given a 12-digit ISBN prefix (e.g. `978014300723`):
 
-* Deployment instructions
+1. Multiply each digit alternately by 1 and 3
+2. Sum the results
+3. Take modulo 10
+4. Subtract from 10 (if result is 10, use 0)
 
-* ...
+Example: `978014300723` → check digit `4` → `9780143007234`
+
+See [docs/check_digit_generator.md](docs/check_digit_generator.md) for detailed documentation and a process flow chart.
+
+## Usage
+
+```ruby
+generator = CheckedBarcodeGenerator.perform("978014300723")
+generator.success? # => true
+generator.result   # => "9780143007234"
+```
+
+The service validates that the input is exactly 12 numeric digits with a valid EAN prefix (`978` or `979`).

--- a/app/services/checked_barcode_generator.rb
+++ b/app/services/checked_barcode_generator.rb
@@ -11,8 +11,8 @@ class CheckedBarcodeGenerator
 
   def perform
     check_length
-    check_numeric if success?
-    check_valid_ean_prefix if success?
+    check_numeric
+    check_valid_ean_prefix
     @result = join_check_digit(generate_check_digit) if success?
   end
 

--- a/app/services/checked_barcode_generator.rb
+++ b/app/services/checked_barcode_generator.rb
@@ -34,7 +34,7 @@ class CheckedBarcodeGenerator
   def check_valid_ean_prefix
     ean_prefix = unchecked_isbn_barcode[0..2]
     unless VALID_EAN_PREFIXES.include?(ean_prefix)
-      errors.add(:base, "invalid EAN prefix of #{ean_prefix} - should be one of #{VALID_EAN_PREFIXES}")
+      errors.add(:base, "invalid EAN prefix of #{ean_prefix} - should be one of #{VALID_EAN_PREFIXES.join(', ')}")
     end
   end
 

--- a/app/services/checked_barcode_generator.rb
+++ b/app/services/checked_barcode_generator.rb
@@ -1,0 +1,53 @@
+class CheckedBarcodeGenerator
+  include UseCase
+
+  VALID_EAN_PREFIXES = [ "978", "979" ].freeze
+
+  attr_reader :result
+
+  def initialize(unchecked_isbn_barcode)
+    @unchecked_isbn_barcode = unchecked_isbn_barcode.to_s
+  end
+
+  def perform
+    check_length
+    check_numeric if success?
+    check_valid_ean_prefix if success?
+    @result = join_check_digit(generate_check_digit) if success?
+  end
+
+  private
+
+  attr_reader :unchecked_isbn_barcode
+
+  def check_length
+    length = unchecked_isbn_barcode.length
+    if length != 12
+      errors.add(:base, "Submitted code is #{length} characters - an unchecked ISBN-13 barcode should be exactly 12 digits")
+    end
+  end
+
+  def check_numeric
+    errors.add(:base, "Submitted code contains non-numeric characters") unless unchecked_isbn_barcode.match?(/\A\d+\z/)
+  end
+
+  def check_valid_ean_prefix
+    ean_prefix = unchecked_isbn_barcode[0..2]
+    unless VALID_EAN_PREFIXES.include?(ean_prefix)
+      errors.add(:base, "invalid EAN prefix of #{ean_prefix} - should be one of #{VALID_EAN_PREFIXES}")
+    end
+  end
+
+  def generate_check_digit
+    digits = unchecked_isbn_barcode.chars.map(&:to_i)
+    multiplied_digits = digits.map.with_index do |digit, index|
+      index.even? ? digit : digit * 3
+    end
+    remainder = multiplied_digits.sum % 10
+    remainder.zero? ? 0 : 10 - remainder
+  end
+
+  def join_check_digit(check_digit)
+    "#{unchecked_isbn_barcode}#{check_digit}"
+  end
+end

--- a/app/services/use_case.rb
+++ b/app/services/use_case.rb
@@ -1,0 +1,22 @@
+# A pattern from a former colleague - the only reference I could find was in the wayback machine: https://web.archive.org/web/20150905160635/http://webuild.envato.com/blog/a-case-for-use-cases/
+module UseCase
+  extend ActiveSupport::Concern
+  include ActiveModel::Validations
+
+  module ClassMethods
+    # The perform method of a UseCase should always return itself
+    def perform(*args)
+      new(*args).tap { |use_case| use_case.perform }
+    end
+  end
+
+  # implement all the steps required to complete this use case
+  def perform
+    raise NotImplementedError
+  end
+
+  # inside of perform, add errors if the use case did not succeed
+  def success?
+    errors.none?
+  end
+end

--- a/docs/check_digit_generator.md
+++ b/docs/check_digit_generator.md
@@ -15,7 +15,7 @@ Per the business rules set out in the [spec](https://circlepos.com/jobs/), we're
 As the protocol name implies, the barcode is 13 digits long, _including the `check digit`_ (or `checksum` char)
 
 ## EAN
-The 3-digit prefix for the ISBN13 barcode.Per [Wikipedia](https://en.wikipedia.org/wiki/ISBN#Overview), only `978` & `979` have been made available.
+The 3-digit prefix for the ISBN13 barcode. Per [Wikipedia](https://en.wikipedia.org/wiki/ISBN#Overview), only `978` & `979` have been made available.
 
 ## Process Chart
 ```mermaid

--- a/docs/check_digit_generator.md
+++ b/docs/check_digit_generator.md
@@ -1,0 +1,47 @@
+- [ISBN13 Barcode Check Digit Generation](#isbn13-barcode-check-digit-generation)
+  - [Implementation](#implementation)
+  - [Format](#format)
+  - [EAN](#ean)
+  - [Process Chart](#process-chart)
+
+
+# ISBN13 Barcode Check Digit Generation
+[Replaced the ISBN10 protocol in 2007](https://en.wikipedia.org/wiki/ISBN#cite_note-conversion-6)
+
+## Implementation
+Per the business rules set out in the [spec](https://circlepos.com/jobs/), we're only generating a `check digit` not a `checksum`.
+
+## Format
+As the protocol name implies, the barcode is 13 digits long, _including the `check digit`_ (or `checksum` char)
+
+## EAN
+The 3-digit prefix for the ISBN13 barcode.Per [Wikipedia](https://en.wikipedia.org/wiki/ISBN#Overview), only `978` & `979` have been made available.
+
+## Process Chart
+```mermaid
+    graph TD
+    A[Check Barcode Length]
+    B[Check Barcode Format]
+    C[Check EAN validity]
+    Error@{ shape: stadium, label: "Errors (on validity failure)" }
+    subgraph D["Generate Check Digit"]
+    direction TB
+        E[Convert to String]
+        F[Split to separate integers]
+        G[Multiply odd-indexed ints by 3]
+        H[Sum the digits]
+        I["Divide by <code>10</code> and return _remainder_ (<code>modulo</code>)"]
+        J["Minus _remainder_ from <code>10</code>"]
+    E-->F
+    F-->G
+    G-->H
+    H-->I
+    I-->J
+    end
+    A-->B
+    B-->C
+    C-->D
+    A-.->Error
+    B-.->Error
+    C-.->Error
+```

--- a/lib/tasks/isbn.rake
+++ b/lib/tasks/isbn.rake
@@ -1,0 +1,18 @@
+namespace :isbn do
+  desc "Generate check digit for an ISBN-13 barcode prefix. Usage: rake isbn:check_digit[978014300723]"
+  task :check_digit, [ :barcode_prefix ] => :environment do |_t, args|
+    unless args[:barcode_prefix]
+      puts "Usage: rake isbn:check_digit[978014300723]"
+      exit 1
+    end
+
+    generator = CheckedBarcodeGenerator.perform(args[:barcode_prefix])
+
+    if generator.success?
+      puts generator.result
+    else
+      generator.errors.full_messages.each { |msg| puts "Error: #{msg}" }
+      exit 1
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require "rspec/rails"
+
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  abort e.to_s.strip
+end
+
+RSpec.configure do |config|
+  config.fixture_paths = [
+    Rails.root.join("spec/fixtures")
+  ]
+
+  config.use_transactional_fixtures = true
+  config.filter_rails_from_backtrace!
+end

--- a/spec/services/checked_barcode_generator_spec.rb
+++ b/spec/services/checked_barcode_generator_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe CheckedBarcodeGenerator do
       it "is not valid" do
         generator = generate
         expect(generator.success?).to be false
-        expect(generator.errors.full_messages).to include("invalid EAN prefix of 980 - should be one of [\"978\", \"979\"]")
+        expect(generator.errors.full_messages).to include("invalid EAN prefix of 980 - should be one of 978, 979")
       end
     end
   end

--- a/spec/services/checked_barcode_generator_spec.rb
+++ b/spec/services/checked_barcode_generator_spec.rb
@@ -15,6 +15,36 @@ RSpec.describe CheckedBarcodeGenerator do
       end
     end
 
+    context "with Old Man's War by John Scalzi (Tor paperback)" do
+      let(:unchecked_isbn_barcode) { "978076531524" }
+
+      it "generates check digit 3" do
+        generator = generate
+        expect(generator.success?).to be true
+        expect(generator.result).to eq("9780765315243")
+      end
+    end
+
+    context "with The Colour of Magic by Terry Pratchett (Corgi edition)" do
+      let(:unchecked_isbn_barcode) { "978055216659" }
+
+      it "generates check digit 1" do
+        generator = generate
+        expect(generator.success?).to be true
+        expect(generator.result).to eq("9780552166591")
+      end
+    end
+
+    context "with a 979 EAN prefix" do
+      let(:unchecked_isbn_barcode) { "979888645174" }
+
+      it "generates the correct check digit" do
+        generator = generate
+        expect(generator.success?).to be true
+        expect(generator.result).to eq("9798886451740")
+      end
+    end
+
     context "when the check digit is 0" do
       let(:unchecked_isbn_barcode) { "978020137960" }
 

--- a/spec/services/checked_barcode_generator_spec.rb
+++ b/spec/services/checked_barcode_generator_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe CheckedBarcodeGenerator do
+  subject(:generate) { described_class.perform(unchecked_isbn_barcode) }
+
+  let(:unchecked_isbn_barcode) { "978014300723" }
+
+  describe "#perform" do
+    context "with a valid ISBN-13 barcode without a check digit" do
+      it "generates the correct check digit and appends it" do
+        generator = generate
+        expect(generator.success?).to be true
+        expect(generator.errors).to be_empty
+        expect(generator.result).to eq("9780143007234")
+      end
+    end
+
+    context "when the check digit is 0" do
+      let(:unchecked_isbn_barcode) { "978020137960" }
+
+      it "returns 0 instead of 10" do
+        generator = generate
+        expect(generator.success?).to be true
+        expect(generator.result).to eq("9780201379600")
+      end
+    end
+  end
+
+  describe "validations" do
+    context "with too long a barcode" do
+      let(:unchecked_isbn_barcode) { "9781234567890" }
+
+      it "is not valid" do
+        generator = generate
+        expect(generator.success?).to be false
+        expect(generator.errors.full_messages).to include("Submitted code is 13 characters - an unchecked ISBN-13 barcode should be exactly 12 digits")
+      end
+    end
+
+    context "with too short a barcode" do
+      let(:unchecked_isbn_barcode) { "97801430072" }
+
+      it "is not valid" do
+        generator = generate
+        expect(generator.success?).to be false
+        expect(generator.errors.full_messages).to include("Submitted code is 11 characters - an unchecked ISBN-13 barcode should be exactly 12 digits")
+      end
+    end
+
+    context "with a non-numeric barcode" do
+      let(:unchecked_isbn_barcode) { "9780143007AB" }
+
+      it "is not valid" do
+        generator = generate
+        expect(generator.success?).to be false
+        expect(generator.errors.full_messages).to include("Submitted code contains non-numeric characters")
+      end
+    end
+
+    context "with an invalid EAN prefix" do
+      let(:unchecked_isbn_barcode) { "980014300723" }
+
+      it "is not valid" do
+        generator = generate
+        expect(generator.success?).to be false
+        expect(generator.errors.full_messages).to include("invalid EAN prefix of 980 - should be one of [\"978\", \"979\"]")
+      end
+    end
+  end
+end

--- a/spec/services/checked_barcode_generator_spec.rb
+++ b/spec/services/checked_barcode_generator_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe CheckedBarcodeGenerator do
       it "generates the correct check digit and appends it" do
         generator = generate
         expect(generator.success?).to be true
-        expect(generator.errors).to be_empty
         expect(generator.result).to eq("9780143007234")
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_when_matching :focus
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
## Summary

- Implements an ISBN-13 check digit generator as a service using the UseCase pattern
- Validates input: length (12 digits), numeric format, and EAN prefix (978/979)
- Full RSpec test coverage including edge case where check digit is 0

## What I'd consider best practice for a Rails feature

- (Normally a story refined by the team, stored in some kind of task tracker — Trello, JIRA or the like) — taken as a given here
- New feature git branch
- New PR (this)
  - CI stack with automated tests
  - Code includes unit tests (RSpec) and view tests where appropriate (eg Capybara or Cypress)
  - Code review done by another member of the team
  - Manual/smoke testing done on a staging environment
    - Details of testing done either on this PR or the related story
- Consistent patterns and separation of concerns (see the `UseCase`)
- CD deployment (optional)
- TDD (optional)

---

### Algorithm

Given a 12-digit ISBN prefix:

1. Take each digit, from left to right and multiply them alternately by 1 and 3
2. Sum those numbers
3. Take mod 10 of the summed figure
4. Subtract from 10 (if the result is 10, use 0)

Example for `978014300723`:

1. (9×1) + (7×3) + (8×1) + (0×3) + (1×1) + (4×3) + (3×1) + (0×3) + (0×1) + (7×3) + (2×1) + (3×3)
2. 86
3. 86 mod 10 = 6
4. 10 - 6 = 4

Therefore the complete ISBN is: `9780143007234`

## Test plan

- [x] `bundle exec rspec` — 6 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [ ] Code review